### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Intallation
 
-```json
+```sh
 pip install freekassa
 ```
 


### PR DESCRIPTION
xed the display of the "pip install freekassa" command in the readme

It used to be displayed like this:
![image](https://user-images.githubusercontent.com/81916132/159711255-c76fb74f-c900-4ad4-958f-15f6469409d3.png)
